### PR TITLE
- v2.11.8

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,5 +1,19 @@
 # PDDL support - What's new?
 
+## [2.11.8] - 2019-07-05
+
+### Fixes
+
+- Activating the extension upon the `pddl.downloadVal` command.
+- Improved Valstep error reporting.
+- Instantaneous actions visualized correctly in object swim-lanes.
+- Valstep error repro export uses full valstep path rather than relying on valstep in the `%path%`. Thanks, Christian.
+
+### New Features
+
+- Added configuration for asynchronous planning services exposing a `/request` RESTful interface. Configuration may be retrieved from a `*.plannerConfiguration.json` or a `.json` file.
+- Tooltip on plan visualization plan selection bars now explain that the size of the bar correspond to the given plan metric value.
+
 ## [2.11.7] - 2019-06-28
 
 ### Preview of VAL tools download
@@ -638,7 +652,8 @@ Note for open source contributors: all notable changes to the "pddl" extension w
 
 Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how to structure this file.
 
-[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.11.7...HEAD
+[Unreleased]: https://github.com/jan-dolejsi/vscode-pddl/compare/v2.11.8...HEAD
+[2.11.8]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.11.7...v2.11.8
 [2.11.7]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.11.5...v2.11.7
 [2.11.5]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.11.4...v2.11.5
 [2.11.4]:https://github.com/jan-dolejsi/vscode-pddl/compare/v2.11.3...v2.11.4

--- a/client/package.json
+++ b/client/package.json
@@ -4,7 +4,7 @@
   "description": "Planning Domain Description Language support",
   "author": "Jan Dolejsi",
   "license": "MIT",
-  "version": "2.11.7",
+  "version": "2.11.8",
   "publisher": "jan-dolejsi",
   "engines": {
     "vscode": "^1.31.0",
@@ -38,6 +38,7 @@
     "onCommand:pddl.showOverview",
     "onCommand:pddl.searchDebugger.start",
     "onCommand:pddl.planning.domains.session.load",
+    "onCommand:pddl.downloadVal",
     "workspaceContains:.planning.domains.session.json",
     "onView:pddl.planning.domains",
     "onView:pddl.tests.explorer",

--- a/client/publish.cmd
+++ b/client/publish.cmd
@@ -13,7 +13,7 @@ call vsce package
 :: https://code.visualstudio.com/docs/editor/extension-gallery#_install-from-a-vsix
 echo Installing the extension locally...
 ::major minor patch
-call code --install-extension pddl-2.11.7.vsix
+call code --install-extension pddl-2.11.8.vsix
 echo Test extension before you continue
 pause
-call vsce publish --packagePath pddl-2.11.7.vsix
+call vsce publish --packagePath pddl-2.11.8.vsix

--- a/client/src/configuration.ts
+++ b/client/src/configuration.ts
@@ -264,34 +264,6 @@ export class PddlConfiguration {
         return newPlannerOptions;
     }
 
-    NO_OPTIONS: OptionsQuickPickItem = { label: 'No options.', options: '', description: '' };
-    optionsHistory: OptionsQuickPickItem[] = [ this.NO_OPTIONS, { label: 'Specify options...', newValue: true, options: '', description: '' }];
-
-    async getPlannerOptions() {
-        let optionsSelected = await vscode.window.showQuickPick(this.optionsHistory,
-            { placeHolder: 'Optionally specify planner switches or press ENTER to use default planner configuration.' });
-
-        if (!optionsSelected) { return null; } // operation canceled by the user by pressing Escape
-        else if (optionsSelected.newValue) {
-            let optionsEntered = await vscode.window.showInputBox({ placeHolder: 'Specify planner options.' });
-            if (!optionsEntered) { return null; }
-            optionsSelected = { label: optionsEntered, options: optionsEntered, description: '' };
-        }
-        else if (optionsSelected !== this.NO_OPTIONS) {
-            // a previous option was selected - lets allow the user to edit it before continuing
-            let optionsEntered = await vscode.window.showInputBox({value: optionsSelected.options, placeHolder: 'Specify planner options.', prompt: 'Adjust the options, if needed and press Enter to continue.'});
-            if (!optionsEntered) { return null; } // canceled by the user
-            optionsSelected = { label: optionsEntered, options: optionsEntered, description: '' };
-        }
-
-        let indexOf = this.optionsHistory.findIndex(option => option.options === optionsSelected.options);
-        if (indexOf > -1) {
-            this.optionsHistory.splice(indexOf, 1);
-        }
-        this.optionsHistory.unshift(optionsSelected); // insert to the first position
-        return optionsSelected.options;
-    }
-
     getPlannerSyntax(): string {
         return vscode.workspace.getConfiguration().get(PLANNER_EXECUTABLE_OPTIONS);
     }
@@ -427,11 +399,4 @@ class ScopeQuickPickItem implements vscode.QuickPickItem {
     description: string;
     target: vscode.ConfigurationTarget;
     uri?: vscode.Uri;
-}
-
-class OptionsQuickPickItem implements vscode.QuickPickItem {
-    label: string;
-    description: string;
-    options: string;
-    newValue?: boolean;
 }

--- a/client/src/planning/PlanFunctionEvaluator.ts
+++ b/client/src/planning/PlanFunctionEvaluator.ts
@@ -26,6 +26,10 @@ export class PlanFunctionEvaluator {
         return this.valueSeqPath && this.valStepPath ? true : false;
     }
 
+    getValStepPath(): string {
+        return this.valStepPath;
+    }
+
     async evaluate(): Promise<Map<Variable, GroundedFunctionValues>> {
         let domainFile = await Util.toPddlFile("domain", this.plan.domain.getText());
         let problemFile = await Util.toPddlFile("problem", this.plan.problem.getText());

--- a/client/src/planning/PlannerAsyncService.ts
+++ b/client/src/planning/PlannerAsyncService.ts
@@ -1,0 +1,127 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Jan Dolejsi. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+// import * as request from 'request';
+import { Uri, workspace } from 'vscode';
+import { PlannerResponseHandler } from './PlannerResponseHandler';
+import { Plan } from '../../../common/src/Plan';
+import { DomainInfo, ProblemInfo } from '../../../common/src/parser';
+import { PddlPlanParser } from '../../../common/src/PddlPlanParser';
+import { Authentication } from '../../../common/src/Authentication';
+import { PlannerService } from './PlannerService';
+import { PlannerConfigurationSelector } from './PlannerConfigurationSelector';
+
+/** Wraps the `/request` planning web service interface. */
+export class PlannerAsyncService extends PlannerService {
+
+    timeout = 60; //this default is overridden by info from the configuration!
+    asyncMode = false;
+
+    constructor(plannerPath: string, private plannerConfiguration: Uri, useAuthentication: boolean, authentication: Authentication) {
+        super(plannerPath, useAuthentication, authentication);
+    }
+
+    getTimeout(): number {
+        return this.timeout;
+    }
+
+    createUrl(): string {
+        return this.plannerPath + '?async=' + this.asyncMode;
+    }
+
+    async createRequestBody(domainFileInfo: DomainInfo, problemFileInfo: ProblemInfo): Promise<any> {
+        let configuration = await this.getConfiguration();
+        if (!configuration) { return null; }
+
+        configuration.planFormat = 'JSON';
+        if ("timeout" in configuration) {
+            this.timeout = configuration.timeout;
+        }
+
+        return {
+            'domain': {
+                'name': domainFileInfo.name,
+                'format': 'PDDL',
+                'content': domainFileInfo.getText()
+            },
+            'problem': {
+                'name': problemFileInfo.name,
+                'format': 'PDDL',
+                'content': problemFileInfo.getText()
+            },
+            'configuration': configuration
+        };
+    }
+
+    processServerResponseBody(responseBody: any, planParser: PddlPlanParser, parent: PlannerResponseHandler, resolve: (plans: Plan[]) => void, reject: (error: Error) => void): void {
+        let _timedout = false;
+        let response_status: string = responseBody['status']['status'];
+        if (["STOPPED", "SEARCHING_BETTER_PLAN"].includes(response_status)) {
+            _timedout = responseBody['status']['reason'] === "TIMEOUT";
+            if (responseBody['plans'].length > 0) {
+                let plansJson = responseBody['plans'];
+                plansJson.forEach((plan: any) => this.parsePlan(plan, planParser));
+
+                let plans = planParser.getPlans();
+                if (plans.length > 0) { parent.handleOutput(plans[0].getText() + '\n'); }
+                else { parent.handleOutput('No plan found.'); }
+
+                resolve(plans);
+                return;
+            }
+            else {
+                // todo: no plan found yet. Poll again later.
+                resolve([]);
+                return;
+            }
+        }
+        else if (response_status === "FAILED") {
+            let error = responseBody['status']['error']['message'];
+            reject(new Error(error));
+            return;
+        }
+        else if (["NOT_INITIALIZED", "INITIATING", "SEARCHING_INITIAL_PLAN"].includes(response_status)) {
+            _timedout = true;
+            let error = `After timeout ${this.timeout} the status is ${response_status}`;
+            reject(new Error(error));
+            return;
+        }
+
+        console.log(_timedout);
+    }
+
+    parsePlan(plan: any, planParser: PddlPlanParser): void {
+        let _makespan: number = plan['makespan'];
+        let _metric: number = plan['metricValue'];
+        let search_performance_info = plan['searchPerformanceInfo'];
+        let _states_evaluated: number = search_performance_info['statesEvaluated'];
+        let _elapsedTimeInSeconds = parseFloat(search_performance_info['timeElapsed']) / 1000;
+        let planSteps = JSON.parse(plan['content']);
+        this.parsePlanSteps(planSteps, planParser);
+
+        planParser.onPlanFinished();
+
+        console.log("Not implemented further." + _makespan + _metric + _states_evaluated + _elapsedTimeInSeconds + planSteps);
+    }
+
+    async getConfiguration(): Promise<any> {
+        if (this.plannerConfiguration.toString() === PlannerConfigurationSelector.DEFAULT.toString()) {
+            return this.createDefaultConfiguration();
+        }
+        else {
+            let configurationDoc = await workspace.openTextDocument(this.plannerConfiguration);
+            let configurationString = configurationDoc.getText();
+            return JSON.parse(configurationString);
+        }
+    }
+
+    createDefaultConfiguration(): any {
+        return {
+            "planFormat": "JSON",
+            "timeout": this.timeout
+        };
+    }
+}

--- a/client/src/planning/PlannerConfigurationSelector.ts
+++ b/client/src/planning/PlannerConfigurationSelector.ts
@@ -1,0 +1,65 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Jan Dolejsi. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import { window, Uri, QuickPickItem } from 'vscode';
+import * as path from 'path';
+
+export class PlannerConfigurationSelector {
+
+    public static readonly DEFAULT = Uri.parse("configuration:/default");
+
+    constructor(private problemPath: Uri) {
+    }
+
+    async getConfiguration(): Promise<Uri> {
+        let selectedItem = await window.showQuickPick<PlannerConfigurationItem>([useDefaultsItem, selectedConfigurationItem], { placeHolder: 'Select planner configuration from a .json file...' });
+        if (!selectedItem) { return null; }
+
+        switch (selectedItem) {
+            case useDefaultsItem:
+                return PlannerConfigurationSelector.DEFAULT;
+            case selectedConfigurationItem:
+                return await this.selectConfigurationFile();
+            default:
+                if (selectedConfigurationItem instanceof PlannerConfigurationUriItem) {
+                    return (<PlannerConfigurationUriItem>selectedConfigurationItem).uri;
+                }
+                else {
+                    throw new Error("Unexpected selected item type: " + typeof (selectedConfigurationItem));
+                }
+        }
+    }
+
+    async selectConfigurationFile(): Promise<Uri> {
+        let selectedUris = await window.showOpenDialog({
+            canSelectMany: false, filters: {
+                'Planner Configuration JSON': ['plannerConfiguration.json'],
+                'JSON': ['json']
+            },
+            defaultUri: this.problemPath
+        });
+
+        if (!selectedUris) { return null; }
+
+        return selectedUris[0];
+    }
+
+}
+
+class PlannerConfigurationItem implements QuickPickItem {
+
+    constructor(public readonly label: string, public readonly description?: string) {
+    }
+}
+
+class PlannerConfigurationUriItem extends PlannerConfigurationItem {
+
+    constructor(public readonly uri: Uri) {
+        super(path.basename(uri.fsPath), path.dirname(uri.fsPath));
+    }
+}
+
+
+const useDefaultsItem = new PlannerConfigurationItem("Use defaults");
+const selectedConfigurationItem = new PlannerConfigurationItem("Select a configuration file...");

--- a/client/src/planning/PlannerExecutable.ts
+++ b/client/src/planning/PlannerExecutable.ts
@@ -21,10 +21,10 @@ import { Plan } from "../../../common/src/Plan";
 export class PlannerExecutable extends Planner {
 
     // this property stores the reference to the planner child process, while planning is in progress
-    child: process.ChildProcess;
+    private child: process.ChildProcess;
 
-    constructor(plannerPath: string, plannerOptions: string, public plannerSyntax: string, public workingDirectory: string) {
-        super(plannerPath, plannerOptions);
+    constructor(plannerPath: string, private plannerOptions: string, private plannerSyntax: string, private workingDirectory: string) {
+        super(plannerPath);
     }
 
     async plan(domainFileInfo: DomainInfo, problemFileInfo: ProblemInfo, planParser: PddlPlanParser, parent: PlannerResponseHandler): Promise<Plan[]> {

--- a/client/src/planning/PlannerOptionsProvider.ts
+++ b/client/src/planning/PlannerOptionsProvider.ts
@@ -22,6 +22,6 @@ export interface PlannerOptionsProvider {
  * Planning request context.
  */
 export interface PlanningRequestContext {
-    domain: DomainInfo,
-    problem: ProblemInfo
+    domain: DomainInfo;
+    problem: ProblemInfo;
 }

--- a/client/src/planning/PlannerSyncService.ts
+++ b/client/src/planning/PlannerSyncService.ts
@@ -1,0 +1,84 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Jan Dolejsi. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+'use strict';
+
+import { PlannerResponseHandler } from './PlannerResponseHandler';
+import { Plan } from '../../../common/src/Plan';
+import { DomainInfo, ProblemInfo } from '../../../common/src/parser';
+import { PddlPlanParser } from '../../../common/src/PddlPlanParser';
+import { Authentication } from '../../../common/src/Authentication';
+import { PlannerService } from './PlannerService';
+
+/** Wraps the `/solve` planning web service interface. */
+export class PlannerSyncService extends PlannerService {
+
+    constructor(plannerPath: string, private plannerOptions: string, useAuthentication: boolean, authentication: Authentication) {
+        super(plannerPath, useAuthentication, authentication);
+    }
+
+    createUrl(): string {
+
+        let url = this.plannerPath;
+        if (this.plannerOptions) {
+            url = `${url}?${this.plannerOptions}`;
+        }
+        return url;
+    }
+
+    getTimeout(): number {
+        return 60;
+    }
+
+    createRequestBody(domainFileInfo: DomainInfo, problemFileInfo: ProblemInfo): Promise<any> {
+        let body = {
+            "domain": domainFileInfo.getText(),
+            "problem": problemFileInfo.getText()
+        };
+
+        return Promise.resolve(body);
+    }
+
+    processServerResponseBody(responseBody: any, planParser: PddlPlanParser, parent: PlannerResponseHandler,
+        resolve: (plans: Plan[]) => void, reject: (error: Error) => void): void {
+        let status = responseBody["status"];
+
+        if (status === "error") {
+            let result = responseBody["result"];
+
+            let resultOutput = result["output"];
+            if (resultOutput) {
+                parent.handleOutput(resultOutput);
+            }
+
+            let resultError = result["error"];
+            if (resultError) {
+                parent.handleOutput(resultError);
+                resolve([]);
+            }
+            else {
+                reject(new Error("An error occurred while solving the planning problem: " + JSON.stringify(result)));
+            }
+            return;
+        }
+        else if (status !== "ok") {
+            reject(new Error(`Planner service failed with status ${status}.`));
+            return;
+        }
+
+        let result = responseBody["result"];
+        let resultOutput = result["output"];
+        if (resultOutput) {
+            parent.handleOutput(resultOutput);
+        }
+
+        this.parsePlanSteps(result['plan'], planParser);
+
+        let plans = planParser.getPlans();
+        if (plans.length > 0) { parent.handleOutput(plans[0].getText() + '\n'); }
+        else { parent.handleOutput('No plan found.'); }
+
+        resolve(plans);
+    }
+}

--- a/client/src/planning/PlannerUserOptionsSelector.ts
+++ b/client/src/planning/PlannerUserOptionsSelector.ts
@@ -1,0 +1,43 @@
+/* --------------------------------------------------------------------------------------------
+ * Copyright (c) Jan Dolejsi. All rights reserved.
+ * Licensed under the MIT License. See License.txt in the project root for license information.
+ * ------------------------------------------------------------------------------------------ */
+import * as vscode from 'vscode';
+
+export class PlannerUserOptionsSelector {
+
+    private NO_OPTIONS: OptionsQuickPickItem = { label: 'No options.', options: '', description: '' };
+    private optionsHistory: OptionsQuickPickItem[] = [ this.NO_OPTIONS, { label: 'Specify options...', newValue: true, options: '', description: '' }];
+
+    async getPlannerOptions() {
+        let optionsSelected = await vscode.window.showQuickPick(this.optionsHistory,
+            { placeHolder: 'Optionally specify planner switches or press ENTER to use default planner configuration.' });
+
+        if (!optionsSelected) { return null; } // operation canceled by the user by pressing Escape
+        else if (optionsSelected.newValue) {
+            let optionsEntered = await vscode.window.showInputBox({ placeHolder: 'Specify planner options.' });
+            if (!optionsEntered) { return null; }
+            optionsSelected = { label: optionsEntered, options: optionsEntered, description: '' };
+        }
+        else if (optionsSelected !== this.NO_OPTIONS) {
+            // a previous option was selected - lets allow the user to edit it before continuing
+            let optionsEntered = await vscode.window.showInputBox({value: optionsSelected.options, placeHolder: 'Specify planner options.', prompt: 'Adjust the options, if needed and press Enter to continue.'});
+            if (!optionsEntered) { return null; } // canceled by the user
+            optionsSelected = { label: optionsEntered, options: optionsEntered, description: '' };
+        }
+
+        let indexOf = this.optionsHistory.findIndex(option => option.options === optionsSelected.options);
+        if (indexOf > -1) {
+            this.optionsHistory.splice(indexOf, 1);
+        }
+        this.optionsHistory.unshift(optionsSelected); // insert to the first position
+        return optionsSelected.options;
+    }
+}
+
+class OptionsQuickPickItem implements vscode.QuickPickItem {
+    label: string;
+    description: string;
+    options: string;
+    newValue?: boolean;
+}

--- a/client/src/planning/planner.ts
+++ b/client/src/planning/planner.ts
@@ -10,11 +10,10 @@ import { Plan } from '../../../common/src/Plan';
 import { PddlPlanParser } from '../../../common/src/PddlPlanParser';
 
 export abstract class Planner {
-    epsilon = 1e-3;
 
     planningProcessKilled: boolean;
 
-    constructor(public plannerPath: string, public plannerOptions: string) {
+    constructor(protected readonly plannerPath: string) {
 
     }
 

--- a/common/src/FileInfo.ts
+++ b/common/src/FileInfo.ts
@@ -13,10 +13,14 @@ export abstract class FileInfo {
     private status: FileStatus = FileStatus.Parsed;
     private parsingProblems: ParsingProblem[] = [];
 
-    constructor(public fileUri: string, public version: number, public name: string) {
+    constructor(public readonly fileUri: string, private version: number, public readonly name: string) {
     }
 
     abstract getLanguage(): PddlLanguage;
+
+    getVersion(): number {
+        return this.version;
+    }
 
     getText(): string {
         return this.text;
@@ -122,12 +126,12 @@ export abstract class FileInfo {
             let commentStartColumn = line.indexOf(';');
             let match = regexp.exec(line);
             if (match) {
-                if (commentStartColumn > -1 && match.index > commentStartColumn) continue;
+                if (commentStartColumn > -1 && match.index > commentStartColumn) { continue; }
 
                 let range = new PddlRange(lineIdx, match.index, lineIdx, match.index + match[0].length);
                 let shouldContinue = callback.apply(this, [range, line]);
 
-                if (!shouldContinue) return;
+                if (!shouldContinue) { return; }
             }
         }
     }
@@ -185,11 +189,11 @@ export class Variable {
     }
 
     bind(objects: ObjectInstance[]): Variable {
-        if (this.parameters.length != objects.length) {
+        if (this.parameters.length !== objects.length) {
             throw new Error(`Invalid objects ${objects} for function ${this.getFullName()} parameters ${this.parameters}.`);
         }
         let fullName = this.name;
-        if (objects) fullName += " " + objects.map(o => o.name).join(" ");
+        if (objects) { fullName += " " + objects.map(o => o.name).join(" "); }
         return new Variable(fullName, objects);
     }
 

--- a/common/src/PddlPlanParser.ts
+++ b/common/src/PddlPlanParser.ts
@@ -13,15 +13,15 @@ import { DomainInfo, ProblemInfo } from './parser';
  */
 export class PddlPlanParser {
 
-    plans: Plan[] = [];
-    public static planStepPattern = /^\s*((\d+|\d+\.\d+)\s*:)?\s*\((.*)\)\s*(\[\s*(\d+|\d+\.\d+)\s*\])?\s*$/gim;
-    planStatesEvaluatedPattern = /^;\s*States evaluated[\w ]*:[ ]*(\d*)\s*$/i;
-    planCostPattern = /[\w ]*(cost|metric)[\D :]*[ ]*(\d*|\d*\.\d*)\s*$/i
+    private readonly plans: Plan[] = [];
+    public static readonly planStepPattern = /^\s*((\d+|\d+\.\d+)\s*:)?\s*\((.*)\)\s*(\[\s*(\d+|\d+\.\d+)\s*\])?\s*$/gim;
+    private readonly planStatesEvaluatedPattern = /^;\s*States evaluated[\w ]*:[ ]*(\d*)\s*$/i;
+    private readonly planCostPattern = /[\w ]*(cost|metric)[\D :]*[ ]*(\d*|\d*\.\d*)\s*$/i;
 
-    planBuilder: PlanBuilder;
-    endOfBufferToBeParsedNextTime = '';
+    private planBuilder: PlanBuilder;
+    private endOfBufferToBeParsedNextTime = '';
 
-    constructor(private domain: DomainInfo, private problem: ProblemInfo, private epsilon: number, private onPlanReady?: (plans: Plan[]) => void) {
+    constructor(private domain: DomainInfo, private problem: ProblemInfo, public readonly epsilon: number, private onPlanReady?: (plans: Plan[]) => void) {
         this.planBuilder = new PlanBuilder(epsilon);
     }
 
@@ -36,7 +36,7 @@ export class PddlPlanParser {
         let nextEndLine: number;
         while ((nextEndLine = textString.indexOf('\n', lastEndLine)) > -1) {
             let nextLine = textString.substring(lastEndLine, nextEndLine + 1);
-            if (nextLine.trim()) this.appendLine(nextLine);
+            if (nextLine.trim()) { this.appendLine(nextLine); }
             lastEndLine = nextEndLine + 1;
         }
         if (textString.length > lastEndLine) {
@@ -81,7 +81,7 @@ export class PddlPlanParser {
      */
     appendStep(planStep: PlanStep) {
         this.planBuilder.add(planStep);
-        if (!this.planBuilder.parsingPlan) this.planBuilder.parsingPlan = true;
+        if (!this.planBuilder.parsingPlan) { this.planBuilder.parsingPlan = true; }
     }
 
     /**
@@ -98,7 +98,7 @@ export class PddlPlanParser {
             this.planBuilder = new PlanBuilder(this.epsilon);
         }
 
-        if (this.onPlanReady) this.onPlanReady.apply(this, [this.plans]);
+        if (this.onPlanReady) { this.onPlanReady.apply(this, [this.plans]); }
     }
 
     /** Gets current plan's provisional makespan. */

--- a/common/src/PddlWorkspace.ts
+++ b/common/src/PddlWorkspace.ts
@@ -175,7 +175,7 @@ export class PddlWorkspace extends EventEmitter {
         let folder = this.upsertFolder(folderUri);
 
         folder.remove(fileInfo);
-        fileInfo = await this.parseFile(fileInfo.fileUri, fileInfo.getLanguage(), fileInfo.version, fileInfo.getText());
+        fileInfo = await this.parseFile(fileInfo.fileUri, fileInfo.getLanguage(), fileInfo.getVersion(), fileInfo.getText());
         folder.add(fileInfo);
         this.emit(PddlWorkspace.UPDATED, fileInfo);
 


### PR DESCRIPTION
- Activating the extension upon the `pddl.downloadVal` command.
- Improved Valstep error reporting.
- Instantaneous actions visualized correctly in object swim-lanes.
- Valstep error repro export uses full valstep path rather than relying on valstep in the `%path%`. Thanks, Christian.
- Added configuration for asynchronous planning services exposing a `/request` RESTful interface. Configuration may be retrieved from a `*.plannerConfiguration.json` or a `.json` file.
- Tooltip on plan visualization plan selection bars now explain that the size of the bar correspond to the given plan metric value.